### PR TITLE
Update Visual Studio references to 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,9 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
 ELSE()
     # If not gcc and on WIN32 we're using visual studio, perform related checks here.
     IF(WIN32) 
-        # If using visual studio's compiler make sure we're using at least version 12
-        IF(MSVC_VERSION LESS 1800)
-            MESSAGE(FATAL_ERROR "MSVC 12 or higher is required to build this library")
+        # If using visual studio's compiler make sure we're using at least version 17
+        IF(MSVC_VERSION LESS 1930)
+            MESSAGE(FATAL_ERROR "MSVC 17 or higher is required to build this library")
         ENDIF()
         
         SET(_WIN32_WINNT 0x0601 CACHE INTERNAL "Setting _WIN32_WINNT to 0x0601 for Windows 7 minimum APIs")
@@ -78,7 +78,7 @@ ELSE()
 
         # If there hasn't been a tbb platform set (probably not on a win32 platform)
         # then set the TBB_ARCH_PLATFORM environment variable manually.
-        SET(ENV{TBB_ARCH_PLATFORM} "ia32/vc12")
+        SET(ENV{TBB_ARCH_PLATFORM} "ia32/vc17")
         
         ADD_DEFINITIONS (/D _WIN32_WINNT=${_WIN32_WINNT})
         MESSAGE(STATUS "- MSVC: Set minimum Windows API version")
@@ -98,10 +98,10 @@ ELSE()
 				set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
 				set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /bigobj")
 			endif ()
-			if (MSVC_VERSION GREATER 1800 OR MSVC_VERSION EQUAL 1800)
-				option(ANH_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
-			else()
-				set(ANH_BUILD_MSVC_MP FALSE CACHE BOOL "Compiler option /MP requires at least Visual Studio 2013 (VS12) or newer" FORCE)
+                        if (MSVC_VERSION GREATER 1930 OR MSVC_VERSION EQUAL 1930)
+                                option(ANH_BUILD_MSVC_MP "Enable build with multiple processes in Visual Studio" TRUE)
+                        else()
+                                set(ANH_BUILD_MSVC_MP FALSE CACHE BOOL "Compiler option /MP requires at least Visual Studio 2022 (VS17) or newer" FORCE)
 			endif()
 			
 			if(ANH_BUILD_MSVC_MP)

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ The MMOServer is the flagship project for the [SWG:ANH Team][1]. It is a cross p
 
 *   C++0x Compatible Compiler
 
-    Windows: Visual Studio 2013 or higher is required
+    Windows: Visual Studio 2022 or higher is required
     Unix: GCC 4.6 or higher is required
     
 ### Windows Builds ###

--- a/build_server.bat
+++ b/build_server.bat
@@ -189,14 +189,14 @@ rem ----------------------------------------------------------------------------
 rem --- Start of BUILD_ENVIRONMENT ---------------------------------------------
 :BUILD_ENVIRONMENT
 
-if not exist "%VS120COMNTOOLS%" (
-  set "VS120COMNTOOLS=%PROGRAMFILES(X86)%\Microsoft Visual Studio 12.0\Common7\Tools"
-  if not exist "!VS120COMNTOOLS!" (
-  	  set "VS120COMNTOOLS=%PROGRAMFILES%\Microsoft Visual Studio 12.0\Common7\Tools"
-  	  if not exist "!VS120COMNTOOLS!" (          
+if not exist "%VS170COMNTOOLS%" (
+  set "VS170COMNTOOLS=%PROGRAMFILES(X86)%\Microsoft Visual Studio\2022\Community\Common7\Tools"
+  if not exist "!VS170COMNTOOLS!" (
+  	  set "VS170COMNTOOLS=%PROGRAMFILES%\Microsoft Visual Studio\2022\Community\Common7\Tools"
+  	  if not exist "!VS170COMNTOOLS!" (          
   		    rem TODO: Allow user to enter a path to their base visual Studio directory.
          
-    	    echo ***** Microsoft Visual Studio 12.0 required *****
+    	    echo ***** Microsoft Visual Studio 2022 required *****
     	    exit /b 1
   	  )
   )
@@ -204,7 +204,7 @@ if not exist "%VS120COMNTOOLS%" (
 
 set "MSBUILD=%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe"
 
-call "%VS120COMNTOOLS%\vsvars32.bat" >NUL
+call "%VS170COMNTOOLS%\vsvars32.bat" >NUL
 
 set environment_built=yes
 
@@ -338,7 +338,7 @@ if not exist "%PROJECT_BASE%build" (
 )
 cd "%PROJECT_BASE%build"
 
-cmake -G "Visual Studio 12" -DCMAKE_INSTALL_PREFIX=%PROJECT_BASE% -DENABLE_TEST_REPORT=ON ..
+cmake -G "Visual Studio 17 2022" -DCMAKE_INSTALL_PREFIX=%PROJECT_BASE% -DENABLE_TEST_REPORT=ON ..
 
 if exist "*.cache" del /S /Q "*.cache" >NUL
 

--- a/tools/windows/postbuild.bat
+++ b/tools/windows/postbuild.bat
@@ -17,8 +17,8 @@ if not exist %2\bin\%3\mysqlcppconn.dll (
 
 if %3 == "Debug" (
     if not exist %2\bin\%3\tbb_debug.dll (
-        xcopy %1\deps\src\tbb\build\vc12\ia32\%3\tbb_debug.dll %2\bin\%3\ /I /Y /s
-        xcopy %1\deps\src\tbb\build\vc12\ia32\%3\tbbmalloc_debug.dll %2\bin\%3\ /I /Y /s
+        xcopy %1\deps\src\tbb\build\vc17\ia32\%3\tbb_debug.dll %2\bin\%3\ /I /Y /s
+        xcopy %1\deps\src\tbb\build\vc17\ia32\%3\tbbmalloc_debug.dll %2\bin\%3\ /I /Y /s
     )
 
     if not exist %2\bin\%3\zlibd.dll (
@@ -28,8 +28,8 @@ if %3 == "Debug" (
 
 if %3 == "Release" (
     if not exist %2\bin\%3\tbb.dll (
-        xcopy %1\deps\src\tbb\build\vc12\ia32\%3\tbb.dll %2\bin\%3\ /I /Y /s
-        xcopy %1\deps\src\tbb\build\vc12\ia32\%3\tbbmalloc.dll %2\bin\%3\ /I /Y /s
+        xcopy %1\deps\src\tbb\build\vc17\ia32\%3\tbb.dll %2\bin\%3\ /I /Y /s
+        xcopy %1\deps\src\tbb\build\vc17\ia32\%3\tbbmalloc.dll %2\bin\%3\ /I /Y /s
     )
 
     if not exist %2\bin\%3\zlib.dll (


### PR DESCRIPTION
## Summary
- Require Visual Studio 2022 or newer in build documentation and scripts
- Adjust Windows build scripts and CMake settings for VS2022
- Update post-build script to copy TBB libraries from vc17 paths
