### PR TITLE
Update dependency download URLs to swganh repository

### DIFF
--- a/build_server.bat
+++ b/build_server.bat
@@ -83,7 +83,7 @@ rem --- Start of SET_DEFAULTS --------------------------------------------------
 
 set DEPENDENCIES_VERSION=0.6.0
 set DEPENDENCIES_FILE=mmoserver-deps-%DEPENDENCIES_VERSION%.tar.bz2
-set DEPENDENCIES_URL=https://github.com/obi-two/Unofficial_Hope/releases/download/Downloads/%DEPENDENCIES_FILE%
+set DEPENDENCIES_URL=https://github.com/swganh/mmoserver/releases/download/v%DEPENDENCIES_VERSION%/%DEPENDENCIES_FILE%
 set "PROJECT_BASE=%~dp0"
 set "PROJECT_DRIVE=%~d0"
 set PATH=%PROJECT_BASE%tools\windows;%PATH%
@@ -255,7 +255,7 @@ if not exist "data\heightmaps\%1.hmpw" (
 	if not exist "data\heightmaps\%1.hmpw.zip" (
 		echo ** Downloading Heightmap for %1 **
 		echo.
-		"wget" --no-check-certificate https://github.com/obi-two/Unofficial_Hope/releases/download/Downloads/%1.hmpw.zip -O data\heightmaps\%1.hmpw.zip
+                "wget" --no-check-certificate https://github.com/swganh/mmoserver/releases/download/Downloads/%1.hmpw.zip -O data\heightmaps\%1.hmpw.zip
 		echo ** Downloading heightmap complete **
 	)
 

--- a/build_server.sh
+++ b/build_server.sh
@@ -42,7 +42,7 @@ if [ ! -d $basedir/deps ]; then
     
     # Look for the dependencies source file and download if missing
     if [ ! -f $basedir/$filename ]; then
-        wget -nc --no-check-certificate https://github.com/obi-two/Unofficial_Hope/releases/download/Downloads/$filename
+        wget -nc --no-check-certificate https://github.com/swganh/mmoserver/releases/download/v$version/$filename
     fi
     
     # Unpack the dependencies and build the deps


### PR DESCRIPTION
## Summary
- point build scripts to swganh/mmoserver release downloads for dependencies
- update heightmap downloads to use swganh repo

## Testing
- `bash -n build_server.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a2440ab9b88320b4799137a00775e5